### PR TITLE
Use Crystal's remove in macro

### DIFF
--- a/src/bindings/gio/resource.cr
+++ b/src/bindings/gio/resource.cr
@@ -8,8 +8,7 @@ module Gio
     {%
       `glib-compile-resources --target crystal-gio-resource.gresource #{resource_file}`
       data = read_file("crystal-gio-resource.gresource")
-      # FIXME: This wont work on windows
-      `rm crystal-gio-resource.gresource`
+      `crystal eval 'File.delete("crystal-gio-resource.gresource")'`
     %}
     begin
       resource_data = {{ data }}


### PR DESCRIPTION
Saw a FIXME note on `gio/resource.cr` about `rm`. This PR calls `Crystal's File#delete` using `crystal eval` as a cross-platform alternative.

Not sure if using crystal eval like that has any downsides, but the spec passes (& the gresource binary gets deleted successfully)!