### PR TITLE
Add sourcedir option to the `register_resource` macro

### DIFF
--- a/src/bindings/gio/resource.cr
+++ b/src/bindings/gio/resource.cr
@@ -4,9 +4,9 @@ module Gio
   # This macro runs `glib-compile-resources` at compile time, so the XML is only needed at compile time.
   #
   # See `examples/resource.cr` for more info.
-  macro register_resource(resource_file)
+  macro register_resource(resource_file, sourcedir = ".")
     {%
-      `glib-compile-resources --target crystal-gio-resource.gresource #{resource_file}`
+      `glib-compile-resources --sourcedir #{sourcedir} --target crystal-gio-resource.gresource #{resource_file}`
       data = read_file("crystal-gio-resource.gresource")
       # FIXME: This wont work on windows
       `rm crystal-gio-resource.gresource`


### PR DESCRIPTION
I set the default value of `sourcedir` to "." (since default is current dir), however, let me know if you'd like it to be nil instead and let `glib-compile-resources` handle it (`sourcedir ? "--sourcedir ...`) 😅

closes: #29