### PR TITLE
Fix widget templates with hugopl/gi-crystal#64

### DIFF
--- a/src/bindings/gtk/widget_template.cr
+++ b/src/bindings/gtk/widget_template.cr
@@ -48,8 +48,8 @@ module Gtk
       end
 
       def self._instance_init(instance : Pointer(LibGObject::TypeInstance), type : Pointer(LibGObject::TypeClass)) : Nil
-        LibGtk.gtk_widget_init_template(instance)
         previous_def
+        LibGtk.gtk_widget_init_template(instance)
       end
     end
   end


### PR DESCRIPTION
This allows widget templates to work with https://github.com/hugopl/gi-crystal/pull/64
Without this PR, the crystal object hasn't even been created when gtk creates the widgets, which results in a segmentation fault.