### PR TITLE
Orphan gh-pages branch on docs build

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,4 +22,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs
-          destination_dir: ./docs
+          force_orphan: true


### PR DESCRIPTION
This PR enables the `force_orphan` option on the gh-pages action. It will clear commit history on push (see: https://github.com/geopjr-forks/gtk4.cr/tree/gh-pages)

I also removed the `destination_dir: ./docs` as there's no reason to have an old copy of the repo there. (You might have to change this setting to `/` if it's `/docs`):
![gh pages settings page with the following text:
Branch
Your GitHub Pages site is currently being built from the gh-pages branch. Learn more.
Learn how to add a Jekyll theme to your site.
the Directory dropdown is open and the cursor is hovering the / root option. Below it there is the /docs option.
](https://user-images.githubusercontent.com/18014039/190655537-14ffa8a6-5b34-431e-b37b-df4aee3ddd26.png)

## Results:

before: `Receiving objects: 100% (46671/46671), 89.76 MiB | 794.00 KiB/s, done.`
after: `Receiving objects: 100% (2942/2942), 4.97 MiB | 578.00 KiB/s, done.`

fixes: #37 (?)