### PR TITLE
Add `libgtk-4-dev` as dependency for Ubuntu in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The documentation will be found at `docs/index.html`.
 You need the GTK libraries and their GObjectIntrospection files.
 
 - Archlinux: `pacman -S gtk4 gobject-introspection`
-- Ubuntu: `apt-get install libgtk-4-1 libgirepository1.0-dev gobject-introspection gir1.2-gtk-4.0`
+- Ubuntu: `apt-get install libgtk-4-1 libgtk-4-dev libgirepository1.0-dev gobject-introspection gir1.2-gtk-4.0`
 - macOS: `brew install gobject-introspection gtk4`
 
 Be welcome to create a PR updating this readme once you know what packages are needed by your distro to run the


### PR DESCRIPTION
Without the `libgtk-4-dev` package installed on Ubuntu, building helloworld example gives an error:

```
Dependencies are satisfied
Building: helloworld
Error target helloworld failed to compile:
/usr/bin/ld: cannot find -lgtk-4 (this usually means you need to install the development package for libgtk-4): No such file or directory
collect2: error: ld returned 1 exit status
Error: execution of command failed with code: 1: `cc "${@}" -o /home/aram/Projects/crystal/gtk4test/bin/helloworld  -rdynamic -L/snap/crystal/1466/bin/../lib/crystal -lgtk-4 -lgio-2.0 -lgobject-2.0 -lglib-2.0 -lgobject-2.0 -lglib-2.0 -lglib-2.0 -lgobject-2.0 -lglib-2.0 -lm -lgc -lpthread -levent -lrt -lpthread -ldl`
```

Installing the `libgtk-4-dev` package fixes that.