### PR TITLE
Do nothing when finalizing a `Gtk::Window`.

### DIFF
--- a/src/bindings/gtk/gi_crystal.cr
+++ b/src/bindings/gtk/gi_crystal.cr
@@ -1,6 +1,11 @@
 module GICrystal
-  # Finalize *object*.
+  # Finalize a `Gtk::Expression` *object*.
   def finalize_instance(object : Gtk::Expression)
     LibGtk.gtk_expression_unref(object)
+  end
+
+  # Finalize a `Gtk::Window` *object*.
+  def finalize_instance(object : Gtk::Window)
+    # When we get here GTK already destroyed the object if it's a Window
   end
 end


### PR DESCRIPTION
At finalize time the window GObject was already deleted by GTK itself.