### PR TITLE
Add example on how to use Gio::ListModel to populate widgets.

### DIFF
--- a/examples/list_widget.cr
+++ b/examples/list_widget.cr
@@ -1,0 +1,76 @@
+require "../src/gtk4"
+
+class ModelItem < GObject::Object
+  @[GObject::Property]
+  property text : String
+
+  def initialize(@text)
+    super()
+  end
+end
+
+class Model < GObject::Object
+  include Gio::ListModel
+
+  @data = [] of ModelItem
+
+  def add_item(text : String)
+    @data << ModelItem.new(text)
+    items_changed(position: @data.size - 1, removed: 0, added: 1)
+  end
+
+  @[GObject::Virtual]
+  def get_n_items : UInt32
+    @data.size.to_u32
+  end
+
+  @[GObject::Virtual]
+  def get_item(pos : UInt32) : GObject::Object?
+    @data[pos]?
+  end
+
+  @[GObject::Virtual]
+  def get_item_type : UInt64
+    ModelItem.g_type
+  end
+end
+
+app = Gtk::Application.new("hello.example.com", Gio::ApplicationFlags::None)
+
+def setup_item(obj : GObject::Object) : Nil
+  list_item = Gtk::ListItem.cast(obj)
+  list_item.child = Gtk::Label.new
+end
+
+def bind_item(obj : GObject::Object)
+  list_item = Gtk::ListItem.cast(obj)
+  list_item.child.as(Gtk::Label).label = list_item.item.as(ModelItem).text
+end
+
+app.activate_signal.connect do
+  window = Gtk::ApplicationWindow.new(application: app, title: "List")
+  window.set_default_size(200, 200)
+
+  list = Gtk::ListView.new
+  model = Model.new
+  list.model = Gtk::SingleSelection.new(model)
+
+  factory = Gtk::SignalListItemFactory.new
+  factory.setup_signal.connect(->setup_item(GObject::Object))
+  factory.bind_signal.connect(->bind_item(GObject::Object))
+  list.factory = factory
+
+  button = Gtk::Button.new(label: "Add Item")
+  button.clicked_signal.connect do
+    model.add_item("Some item")
+  end
+
+  box = Gtk::Box.new(:vertical, 6)
+  box.append(list)
+  box.append(button)
+
+  window.child = box
+  window.present
+end
+
+exit(app.run)

--- a/src/bindings/gtk/binding.yml
+++ b/src/bindings/gtk/binding.yml
@@ -14,6 +14,7 @@ require_after:
 - widget.cr
 - widget_template.cr
 - snapshot.cr
+- signal_list_item_factory.cr
 
 types:
   ButtonPrivate:

--- a/src/bindings/gtk/signal_list_item_factory.cr
+++ b/src/bindings/gtk/signal_list_item_factory.cr
@@ -1,0 +1,20 @@
+# This is here because GTK 4.7 changed this signal signature, so this code bellow is a copy to
+# what would be generated with recent GTK4 versions, so examples/list_widget.cr compiles on CI
+module Gtk
+  {% if MINOR_VERSION < 7 %}
+    struct Gtk::SignalListItemFactory::SetupSignal
+      def connect(handler : Proc(GObject::Object, Nil), *, after : Bool = false) : GObject::SignalConnection
+        _box = ::Box.box(handler)
+        handler = ->(_lib_sender : Pointer(Void), lib_object : Pointer(Void), _lib_box : Pointer(Void)) {
+          # Generator::BuiltInTypeArgPlan
+          object = GObject::Object.new(lib_object, GICrystal::Transfer::None)
+          ::Box(Proc(GObject::Object, Nil)).unbox(_lib_box).call(object)
+        }.pointer
+
+        handler_id = LibGObject.g_signal_connect_data(@source, name, handler,
+          GICrystal::ClosureDataManager.register(_box), ->GICrystal::ClosureDataManager.deregister, after.to_unsafe)
+        GObject::SignalConnection.new(@source, handler_id)
+      end
+    end
+  {% end %}
+end

--- a/src/bindings/gtk/signal_list_item_factory.cr
+++ b/src/bindings/gtk/signal_list_item_factory.cr
@@ -2,7 +2,22 @@
 # what would be generated with recent GTK4 versions, so examples/list_widget.cr compiles on CI
 module Gtk
   {% if MINOR_VERSION < 7 %}
-    struct Gtk::SignalListItemFactory::SetupSignal
+    struct SignalListItemFactory::SetupSignal
+      def connect(handler : Proc(GObject::Object, Nil), *, after : Bool = false) : GObject::SignalConnection
+        _box = ::Box.box(handler)
+        handler = ->(_lib_sender : Pointer(Void), lib_object : Pointer(Void), _lib_box : Pointer(Void)) {
+          # Generator::BuiltInTypeArgPlan
+          object = GObject::Object.new(lib_object, GICrystal::Transfer::None)
+          ::Box(Proc(GObject::Object, Nil)).unbox(_lib_box).call(object)
+        }.pointer
+
+        handler_id = LibGObject.g_signal_connect_data(@source, name, handler,
+          GICrystal::ClosureDataManager.register(_box), ->GICrystal::ClosureDataManager.deregister, after.to_unsafe)
+        GObject::SignalConnection.new(@source, handler_id)
+      end
+    end
+
+    struct SignalListItemFactory::BindSignal
       def connect(handler : Proc(GObject::Object, Nil), *, after : Bool = false) : GObject::SignalConnection
         _box = ::Box.box(handler)
         handler = ->(_lib_sender : Pointer(Void), lib_object : Pointer(Void), _lib_box : Pointer(Void)) {


### PR DESCRIPTION
This example is now crashing, at some point it worked fine, I'm not sure it was a change in GTK libraries that exposed a bug in GICrystal or something else.

Anyway... the crash seems to happen at the interface cast, I experienced issues with interface casts before, I'll let this example here just in case someone are interested in find the issue.

This crash is probably related to why new builds of [RTFM](https://github.com/hugopl/rtfm) also crashes while the old build I have here, with same code as before works.