### PR TITLE
Add alias to `Gtk::Widget#allocate` using integers instead of a `Gdk::Rectangle`

### DIFF
--- a/src/bindings/gdk/clipboard.cr
+++ b/src/bindings/gdk/clipboard.cr
@@ -10,4 +10,3 @@ module Gdk
     end
   end
 end
-

--- a/src/bindings/gtk/widget.cr
+++ b/src/bindings/gtk/widget.cr
@@ -30,6 +30,11 @@ module Gtk
       GObject::Object.new(ptr, GICrystal::Transfer::None)
     end
 
+    # :ditto:
+    def size_allocate(x : Int32, y : Int32, width : Int32, height : Int32, baseline : Int32)
+      size_allocate(Gdk::Rectangle.new(x, y, width, height), baseline)
+    end
+
     # Returns an `Iterator` over widget children. Call `.to_a` on it if you need to allocate an
     # array with all children.
     #


### PR DESCRIPTION
A monkey patch that I'm using for ages... I believe it may be useful for others as well.