### PR TITLE
Add class ensuring for WidgetTemplate

### DIFF
--- a/src/bindings/gtk/widget_template.cr
+++ b/src/bindings/gtk/widget_template.cr
@@ -54,6 +54,12 @@ module Gtk
             LibGtk.gtk_widget_class_bind_template_child_full(klass, {{ child }}, 0, 0_i64)
           {% end %}
         {% end %}
+
+        {% if ui[:ensure_classes] %}
+          {% for child in ui[:ensure_classes] %}
+            LibGObject.g_type_ensure({{ child }}.g_type)
+          {% end %}
+        {% end %}
       end
 
       def self._instance_init(instance : Pointer(LibGObject::TypeInstance), type : Pointer(LibGObject::TypeClass)) : Nil


### PR DESCRIPTION
Someone raised an issue with custom widgets and builder files, https://github.com/GeopJr/ultimate-gtk4-crystal-guide/issues/9#issuecomment-2552407058

The issue is that we need to ensure that the class exists for GTK to bind them. I see gtk-rs does it on template_child, but in that issue's case, the user does not use template_child. This PR adds the following to WidgetTemplate:

`@[Gtk::UiTemplate(resource: "/dev/ui/main.ui", ensure_classes: {MyButton})]`

and calls `LibGObject.g_type_ensure` on every ensure_classes child